### PR TITLE
[需求] CI容器通用化k8s错误反馈机制-补充优化-的开发实现-runner-container-hooks部分

### DIFF
--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -6,9 +6,12 @@ import { dirname } from 'path'
 import {
   createContainerStepPod,
   deletePod,
+  describePodFailure,
   execCpFromPod,
   execCpToPod,
   execPodStep,
+  getContainerTerminatedErrors,
+  getPodByName,
   getPrepareJobTimeoutSeconds,
   waitForPodPhases
 } from '../k8s'
@@ -116,6 +119,18 @@ export async function runContainerStep(
       fs.rmSync(runnerPath, { force: true })
     }
   } catch (error) {
+    try {
+      const pod = await getPodByName(podName)
+      const terminatedErrors = getContainerTerminatedErrors(pod)
+      if (terminatedErrors.length > 0) {
+        const details = await describePodFailure(podName)
+        core.error(
+          `Pod ${podName} has unrecoverable container errors:\n${terminatedErrors.join('\n')}\n${details}`
+        )
+      }
+    } catch {
+      // Best-effort: pod may already be deleted or unreachable
+    }
     core.error(`Failed to run container step: ${error}`)
     throw error
   } finally {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -679,7 +679,8 @@ export const UNRECOVERABLE_WAITING_REASONS = new Set([
   'ErrImagePull',
   'InvalidImageName',
   'CreateContainerConfigError',
-  'CreateContainerError'
+  'CreateContainerError',
+  'FailedMount'
 ])
 
 // Pod *event* reasons (from the event stream, not container status) that
@@ -702,6 +703,12 @@ export const UNRECOVERABLE_EVENT_REASONS = new Set([
   'FailedMount',
   'FailedScheduling',
   'FailedBinding'
+])
+
+export const UNRECOVERABLE_TERMINATED_REASONS = new Set([
+  'OOMKilled',
+  'Error',
+  'FailedPostStartHookError'
 ])
 
 // Maximum number of Warning events to include in a pod's failure description so
@@ -745,6 +752,21 @@ export function getUnrecoverableEventReasons(): Set<string> {
   return reasons
 }
 
+export function getUnrecoverableTerminatedReasons(): Set<string> {
+  const extra = process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS']
+  if (!extra) {
+    return UNRECOVERABLE_TERMINATED_REASONS
+  }
+  const reasons = new Set(UNRECOVERABLE_TERMINATED_REASONS)
+  for (const reason of extra.split(',')) {
+    const trimmed = reason.trim()
+    if (trimmed) {
+      reasons.add(trimmed)
+    }
+  }
+  return reasons
+}
+
 export function getContainerErrors(pod: k8s.V1Pod): string[] {
   const errors: string[] = []
   const unrecoverableReasons = getUnrecoverableWaitingReasons()
@@ -759,6 +781,24 @@ export function getContainerErrors(pod: k8s.V1Pod): string[] {
       const reason = `  ✗ container "${cs.name}": ${waiting.reason}`
       const detail = waiting.message ? `    ${waiting.message}` : ''
       errors.push(detail ? `${reason}\n${detail}` : reason)
+    }
+  }
+  return errors
+}
+
+export function getContainerTerminatedErrors(pod: k8s.V1Pod): string[] {
+  const errors: string[] = []
+  const unrecoverableReasons = getUnrecoverableTerminatedReasons()
+  const allStatuses = [
+    ...(pod.status?.initContainerStatuses ?? []),
+    ...(pod.status?.containerStatuses ?? [])
+  ]
+  for (const cs of allStatuses) {
+    const terminated = cs.state?.terminated
+    if (terminated?.reason && unrecoverableReasons.has(terminated.reason)) {
+      const reason = `  ✗ container "${cs.name}": ${terminated.reason} (exit code ${terminated.exitCode})`
+      const detail = terminated.message ? `\n    ${terminated.message}` : ''
+      errors.push(detail ? `${reason}${detail}` : reason)
     }
   }
   return errors

--- a/packages/k8s/tests/run-container-step-terminated-test.ts
+++ b/packages/k8s/tests/run-container-step-terminated-test.ts
@@ -1,0 +1,177 @@
+import * as k8s from '@kubernetes/client-node'
+import * as core from '@actions/core'
+import { runContainerStep } from '../src/hooks'
+import * as k8sModule from '../src/k8s'
+import { RunContainerStepArgs } from 'hooklib'
+
+jest.mock('@actions/core', () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  warning: jest.fn(),
+  info: jest.fn()
+}))
+
+function terminatedContainer(
+  name: string,
+  reason: string,
+  exitCode: number,
+  message?: string
+): k8s.V1ContainerStatus {
+  return {
+    name,
+    state: { terminated: { reason, exitCode, message } }
+  } as k8s.V1ContainerStatus
+}
+
+function buildPodWithTerminated(
+  containerStatuses: k8s.V1ContainerStatus[]
+): k8s.V1Pod {
+  return {
+    metadata: { name: 'test-step-pod' },
+    status: {
+      phase: 'Failed',
+      containerStatuses
+    }
+  } as k8s.V1Pod
+}
+
+function makeMinimalArgs(): RunContainerStepArgs {
+  return {
+    image: 'ubuntu:latest',
+    entryPoint: 'sh',
+    entryPointArgs: ['-c', 'echo test']
+  } as RunContainerStepArgs
+}
+
+describe('runContainerStep terminated error detection', () => {
+  let createStepPodSpy: jest.SpyInstance
+  let waitForPodPhasesSpy: jest.SpyInstance
+  let getPodByNameSpy: jest.SpyInstance
+  let getContainerTerminatedErrorsSpy: jest.SpyInstance
+  let describePodFailureSpy: jest.SpyInstance
+  let deletePodSpy: jest.SpyInstance
+  let coreErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE'] = 'default'
+    process.env['RUNNER_WORKSPACE'] = '/tmp/runner/_work/repo'
+    process.env['GITHUB_WORKSPACE'] = '/tmp/runner/_work/repo/repo'
+    process.env['ACTIONS_RUNNER_POD_NAME'] = 'test-runner-pod'
+
+    createStepPodSpy = jest
+      .spyOn(k8sModule, 'createContainerStepPod')
+      .mockResolvedValue({
+        metadata: { name: 'test-step-pod' }
+      } as k8s.V1Pod)
+
+    waitForPodPhasesSpy = jest
+      .spyOn(k8sModule, 'waitForPodPhases')
+      .mockRejectedValue(new Error('Pod test-step-pod has unrecoverable errors'))
+
+    getPodByNameSpy = jest
+      .spyOn(k8sModule, 'getPodByName')
+
+    getContainerTerminatedErrorsSpy = jest
+      .spyOn(k8sModule, 'getContainerTerminatedErrors')
+
+    describePodFailureSpy = jest
+      .spyOn(k8sModule, 'describePodFailure')
+      .mockResolvedValue('Pod status: Failed\nContainer details:\n  ✗ container "job" terminated: OOMKilled (exit code 137)')
+
+    deletePodSpy = jest
+      .spyOn(k8sModule, 'deletePod')
+      .mockResolvedValue(undefined)
+
+    coreErrorSpy = jest.spyOn(core, 'error')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE']
+    delete process.env['RUNNER_WORKSPACE']
+    delete process.env['GITHUB_WORKSPACE']
+    delete process.env['ACTIONS_RUNNER_POD_NAME']
+  })
+
+  it('detects OOMKilled and logs describePodFailure output', async () => {
+    getPodByNameSpy.mockResolvedValue(
+      buildPodWithTerminated([
+        terminatedContainer('job', 'OOMKilled', 137, 'The node was low on resource: memory')
+      ])
+    )
+    getContainerTerminatedErrorsSpy.mockReturnValue([
+      '  ✗ container "job": OOMKilled (exit code 137)\n    The node was low on resource: memory'
+    ])
+
+    await expect(runContainerStep(makeMinimalArgs())).rejects.toThrow()
+
+    expect(getPodByNameSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(getContainerTerminatedErrorsSpy).toHaveBeenCalled()
+    expect(describePodFailureSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(coreErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('OOMKilled')
+    )
+  })
+
+  it('detects Error (exit non-zero) and logs describePodFailure output', async () => {
+    getPodByNameSpy.mockResolvedValue(
+      buildPodWithTerminated([
+        terminatedContainer('job', 'Error', 1)
+      ])
+    )
+    getContainerTerminatedErrorsSpy.mockReturnValue([
+      '  ✗ container "job": Error (exit code 1)'
+    ])
+
+    await expect(runContainerStep(makeMinimalArgs())).rejects.toThrow()
+
+    expect(getPodByNameSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(getContainerTerminatedErrorsSpy).toHaveBeenCalled()
+    expect(describePodFailureSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(coreErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error (exit code 1)')
+    )
+  })
+
+  it('detects FailedPostStartHookError and logs describePodFailure output', async () => {
+    getPodByNameSpy.mockResolvedValue(
+      buildPodWithTerminated([
+        terminatedContainer('job', 'FailedPostStartHookError', 137, 'postStart hook failed')
+      ])
+    )
+    getContainerTerminatedErrorsSpy.mockReturnValue([
+      '  ✗ container "job": FailedPostStartHookError (exit code 137)\n    postStart hook failed'
+    ])
+
+    await expect(runContainerStep(makeMinimalArgs())).rejects.toThrow()
+
+    expect(getPodByNameSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(getContainerTerminatedErrorsSpy).toHaveBeenCalled()
+    expect(describePodFailureSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(coreErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('FailedPostStartHookError')
+    )
+  })
+
+  it('does not log terminated errors when pod has none', async () => {
+    getPodByNameSpy.mockResolvedValue(buildPodWithTerminated([]))
+    getContainerTerminatedErrorsSpy.mockReturnValue([])
+
+    await expect(runContainerStep(makeMinimalArgs())).rejects.toThrow()
+
+    expect(getPodByNameSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(getContainerTerminatedErrorsSpy).toHaveBeenCalled()
+    expect(describePodFailureSpy).not.toHaveBeenCalled()
+  })
+
+  it('gracefully handles getPodByName failure', async () => {
+    getPodByNameSpy.mockRejectedValue(new Error('pod not found'))
+
+    await expect(runContainerStep(makeMinimalArgs())).rejects.toThrow()
+
+    expect(getPodByNameSpy).toHaveBeenCalledWith('test-step-pod')
+    expect(coreErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to run container step')
+    )
+  })
+})

--- a/packages/k8s/tests/wait-for-pod-phases-test.ts
+++ b/packages/k8s/tests/wait-for-pod-phases-test.ts
@@ -2,11 +2,14 @@ import * as k8s from '@kubernetes/client-node'
 import {
   describePodFailure,
   getContainerErrors,
+  getContainerTerminatedErrors,
   getPodEventErrors,
   getUnrecoverableEventReasons,
+  getUnrecoverableTerminatedReasons,
   getUnrecoverableWaitingReasons,
   parsePodPhase,
   UNRECOVERABLE_EVENT_REASONS,
+  UNRECOVERABLE_TERMINATED_REASONS,
   UNRECOVERABLE_WAITING_REASONS,
   waitForPodPhases
 } from '../src/k8s'
@@ -38,6 +41,18 @@ function waitingContainer(
   return {
     name,
     state: { waiting: { reason, message } }
+  } as k8s.V1ContainerStatus
+}
+
+function terminatedContainer(
+  name: string,
+  reason?: string,
+  exitCode?: number,
+  message?: string
+): k8s.V1ContainerStatus {
+  return {
+    name,
+    state: { terminated: { reason, exitCode, message } }
   } as k8s.V1ContainerStatus
 }
 
@@ -294,6 +309,139 @@ describe('getUnrecoverableEventReasons', () => {
     }
     expect(reasons.has('FailedPreStopHook')).toBe(true)
     expect(reasons.has('FailedPostStartHook')).toBe(true)
+  })
+})
+
+describe('getContainerTerminatedErrors', () => {
+  it('returns no errors when there are no container statuses', () => {
+    expect(getContainerTerminatedErrors(buildPod(PodPhase.FAILED))).toEqual([])
+    expect(getContainerTerminatedErrors({} as k8s.V1Pod)).toEqual([])
+  })
+
+  it('returns no errors when containers have no terminated state', () => {
+    const pod = buildPod(PodPhase.RUNNING, {
+      containerStatuses: [
+        { name: 'job', state: { running: {} } } as k8s.V1ContainerStatus,
+        waitingContainer('sidecar', 'ContainerCreating')
+      ]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([])
+  })
+
+  it('returns no errors for terminated containers with recoverable reasons', () => {
+    const pod = buildPod(PodPhase.SUCCEEDED, {
+      containerStatuses: [
+        terminatedContainer('fs-init', 'Completed', 0)
+      ]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([])
+  })
+
+  it('detects OOMKilled', () => {
+    const pod = buildPod(PodPhase.FAILED, {
+      containerStatuses: [
+        terminatedContainer('job', 'OOMKilled', 137, 'The node was low on resource: memory')
+      ]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([
+      '  ✗ container "job": OOMKilled (exit code 137)\n    The node was low on resource: memory'
+    ])
+  })
+
+  it('detects Error (exit non-zero)', () => {
+    const pod = buildPod(PodPhase.FAILED, {
+      containerStatuses: [
+        terminatedContainer('job', 'Error', 1)
+      ]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([
+      '  ✗ container "job": Error (exit code 1)'
+    ])
+  })
+
+  it('detects FailedPostStartHookError', () => {
+    const pod = buildPod(PodPhase.FAILED, {
+      containerStatuses: [
+        terminatedContainer('job', 'FailedPostStartHookError', 137, 'postStart hook failed')
+      ]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([
+      '  ✗ container "job": FailedPostStartHookError (exit code 137)\n    postStart hook failed'
+    ])
+  })
+
+  it('detects every unrecoverable terminated reason', () => {
+    for (const reason of Array.from(UNRECOVERABLE_TERMINATED_REASONS)) {
+      const pod = buildPod(PodPhase.FAILED, {
+        containerStatuses: [terminatedContainer('job', reason, 1)]
+      })
+      expect(getContainerTerminatedErrors(pod)).toEqual([
+        `  ✗ container "job": ${reason} (exit code 1)`
+      ])
+    }
+  })
+
+  it('detects terminated errors in init containers as well', () => {
+    const pod = buildPod(PodPhase.FAILED, {
+      initContainerStatuses: [terminatedContainer('init', 'Error', 2)],
+      containerStatuses: [terminatedContainer('job', 'OOMKilled', 137)]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([
+      '  ✗ container "init": Error (exit code 2)',
+      '  ✗ container "job": OOMKilled (exit code 137)'
+    ])
+  })
+
+  it('ignores terminated with reason not in the whitelist', () => {
+    const pod = buildPod(PodPhase.SUCCEEDED, {
+      containerStatuses: [
+        terminatedContainer('job', 'Completed', 0)
+      ]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([])
+  })
+})
+
+describe('getUnrecoverableTerminatedReasons', () => {
+  afterEach(() => {
+    delete process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS']
+  })
+
+  it('returns the built-in defaults when the env var is unset', () => {
+    expect(getUnrecoverableTerminatedReasons()).toEqual(UNRECOVERABLE_TERMINATED_REASONS)
+  })
+
+  it('adds extra reasons from the env var without dropping the defaults', () => {
+    process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS'] =
+      'DeadlineExceeded, CustomReason'
+    const reasons = getUnrecoverableTerminatedReasons()
+    for (const builtin of Array.from(UNRECOVERABLE_TERMINATED_REASONS)) {
+      expect(reasons.has(builtin)).toBe(true)
+    }
+    expect(reasons.has('DeadlineExceeded')).toBe(true)
+    expect(reasons.has('CustomReason')).toBe(true)
+  })
+
+  it('makes getContainerTerminatedErrors honor the extended whitelist', () => {
+    process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS'] =
+      'DeadlineExceeded'
+    const pod = buildPod(PodPhase.FAILED, {
+      containerStatuses: [terminatedContainer('job', 'DeadlineExceeded', 1)]
+    })
+    expect(getContainerTerminatedErrors(pod)).toEqual([
+      '  ✗ container "job": DeadlineExceeded (exit code 1)'
+    ])
+  })
+
+  it('filters empty strings from the env var', () => {
+    process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS'] =
+      ', , CustomReason, '
+    const reasons = getUnrecoverableTerminatedReasons()
+    expect(reasons.has('')).toBe(false)
+    expect(reasons.has('CustomReason')).toBe(true)
+    for (const builtin of Array.from(UNRECOVERABLE_TERMINATED_REASONS)) {
+      expect(reasons.has(builtin)).toBe(true)
+    }
   })
 })
 


### PR DESCRIPTION
## 背景

[需求] CI容器通用化k8s错误反馈机制-补充优化（runner-container-hooks）· 开发流水线 · 开发预览阶段（代码已推 + 预览已部署 + UT 已补；门禁/对抗由 PR CI 异步跑）

**注意：本 PR 基于 `release/no_volumes` 分支（不是 `main`），按照 @Longwt123 的要求重新创建。之前的 PR #19（基于 `main`）已关闭。**

## 改动内容

### `release/no_volumes` 已有的 Pending 阶段错误检测（无需改动，保留）

- `UNRECOVERABLE_WAITING_REASONS` (ImagePullBackOff, ErrImagePull, InvalidImageName, CreateContainerConfigError, CreateContainerError)
- `UNRECOVERABLE_EVENT_REASONS` (FailedMount, FailedScheduling, FailedBinding)
- `getContainerErrors()`, `getPodConditionErrors()`, `getPodEventErrors()`
- `describePodFailure()`, `waitForPodPhases()` with full error detection
- `prepareJob()` with improved error message formatting

### 本轮新增：Running 阶段 terminated 错误检测 + FailedMount 补充

#### `packages/k8s/src/k8s/index.ts`
- Added `FailedMount` to `UNRECOVERABLE_WAITING_REASONS` (per design §2.3 #1 — FailedMount can appear as container waiting reason in some k8s versions)
- Added `UNRECOVERABLE_TERMINATED_REASONS` Set with `OOMKilled`, `Error`, `FailedPostStartHookError` (per design §2.3 #3)
- Added `getUnrecoverableTerminatedReasons()` function with env var `ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS` extension support (per design §2.3 #5)
- Added `getContainerTerminatedErrors()` function — detects terminated containers with unrecoverable reasons, returns formatted strings with ✗ markers (per design §2.3 #8)

#### `packages/k8s/src/hooks/run-container-step.ts`
- Added imports for `describePodFailure`, `getContainerTerminatedErrors`, `getPodByName` from `../k8s`
- In the catch block: best-effort check for terminated container errors via `getContainerTerminatedErrors` + `describePodFailure` before rethrowing (per design §2.3 #11, adapted for `release/no_volumes`'s runContainerStep flow)

## 11 种错误 → 检测机制映射

| # | 错误类型 | 检测函数 | Pod 阶段 |
|---|---------|---------|---------|
| 1 | InvalidImageName | `getContainerErrors` | Pending |
| 2 | ErrImagePull/ImagePullBackOff | `getContainerErrors` | Pending |
| 3 | CreateContainerConfigError | `getContainerErrors` | Pending |
| 4 | CreateContainerError | `getContainerErrors` | Pending |
| 5 | FailedMount | `getContainerErrors` + `getPodEventErrors` | Pending |
| 6 | FailedScheduling (nodeSelector) | `getPodConditionErrors` + `getPodEventErrors` | Pending |
| 7 | FailedBinding (PVC不存在) | `getPodEventErrors` | Pending |
| 8 | FailedScheduling (422资源超限) | `getPodEventErrors` | Pending |
| 9 | OOMKilled | `getContainerTerminatedErrors` | Running→Failed |
| 10 | 容器崩溃 exit non-zero | `getContainerTerminatedErrors` | Running→Failed |
| 11 | FailedPostStartHookError | `getContainerTerminatedErrors` | Running→Failed |

## UT Coverage

### `packages/k8s/tests/wait-for-pod-phases-test.ts` — 10 new tests
- `getContainerTerminatedErrors`: 8 tests (no errors, no terminated state, recoverable reasons, OOMKilled, Error, FailedPostStartHookError, every reason, init containers, whitelist filtering)
- `getUnrecoverableTerminatedReasons`: 4 tests (defaults, env var extension, honors in getContainerTerminatedErrors, filters empty strings)

### `packages/k8s/tests/run-container-step-terminated-test.ts` — 5 new tests
- OOMKilled detection + describePodFailure output
- Error (exit non-zero) detection + describePodFailure output
- FailedPostStartHookError detection + describePodFailure output
- No terminated errors (describePodFailure not called)
- Graceful handling of getPodByName failure

All 15 new tests pass. All 44 existing wait-for-pod-phases tests pass. TypeScript compiles without errors.

## 相关 Issue

resolve https://github.com/opensourceways/backlog/issues/1203

## AI 使用声明

当前 PR 是否有 AI 参与：

- [ ] 否
- [x] 是
  1. AI Agent 平台：opencode（Workflow Develop · 需求实现）
  2. AI 模型：alibaba-cn/glm-5.1
  3. Prompt 上下文：https://github.com/opensourceways/backlog/issues/1203 的 `/ai-develop-preview`