### PR TITLE
fix(k8s): PostCheckout复制时不匹配反复重试add sync after file copy to ensure data durability

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -629,6 +629,14 @@ export async function execCpFromPod(
     `Copying from pod ${podName} ${containerPath} to ${targetRunnerPath}`
   )
 
+  // Clear target before extracting so deleted-on-pod files don't linger locally.
+  // tar.extract() appends into the destination; without this, stale files (e.g.
+  // git-credentials removed by checkout cleanup inside the pod) cause a permanent
+  // hash mismatch that no amount of retrying can resolve.
+  if (fs.existsSync(targetRunnerPath)) {
+    fs.rmSync(targetRunnerPath, { recursive: true, force: true })
+  }
+
   let attempt = 0
   while (true) {
     try {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -410,7 +410,7 @@ export async function execCalculateOutputHashSorted(
   podName: string,
   containerName: string,
   command: string[]
-): Promise<string> {
+): Promise<{ hash: string; lines: string[] }> {
   const exec = new k8s.Exec(kc)
 
   let output = ''
@@ -457,49 +457,49 @@ export async function execCalculateOutputHashSorted(
   outputWriter.end()
 
   // Sort lines for consistent ordering across platforms
-  const sortedOutput =
-    output
-      .split('\n')
-      .filter(line => line.length > 0)
-      .sort()
-      .join('\n') + '\n'
+  const lines = output
+    .split('\n')
+    .filter(line => line.length > 0)
+    .sort()
+  const sortedOutput = lines.join('\n') + '\n'
 
   const hash = createHash('sha256')
   hash.update(sortedOutput)
-  return hash.digest('hex')
+  return { hash: hash.digest('hex'), lines }
 }
 
 export async function localCalculateOutputHashSorted(
   commands: string[]
-): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn(commands[0], commands.slice(1), {
-      stdio: ['ignore', 'pipe', 'ignore']
-    })
+): Promise<{ hash: string; lines: string[] }> {
+  return await new Promise<{ hash: string; lines: string[] }>(
+    (resolve, reject) => {
+      const child = spawn(commands[0], commands.slice(1), {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
 
-    let output = ''
-    child.stdout.on('data', chunk => {
-      output += chunk.toString('utf8')
-    })
-    child.on('error', reject)
-    child.on('close', (code: number) => {
-      if (code === 0) {
-        // Sort lines for consistent ordering across distributions/platforms
-        const sortedOutput =
-          output
+      let output = ''
+      child.stdout.on('data', chunk => {
+        output += chunk.toString('utf8')
+      })
+      child.on('error', reject)
+      child.on('close', (code: number) => {
+        if (code === 0) {
+          // Sort lines for consistent ordering across distributions/platforms
+          const lines = output
             .split('\n')
             .filter(line => line.length > 0)
             .sort()
-            .join('\n') + '\n'
+          const sortedOutput = lines.join('\n') + '\n'
 
-        const hash = createHash('sha256')
-        hash.update(sortedOutput)
-        resolve(hash.digest('hex'))
-      } else {
-        reject(new Error(`child process exited with code ${code}`))
-      }
-    })
-  })
+          const hash = createHash('sha256')
+          hash.update(sortedOutput)
+          resolve({ hash: hash.digest('hex'), lines })
+        } else {
+          reject(new Error(`child process exited with code ${code}`))
+        }
+      })
+    }
+  )
 }
 
 export async function execCpToPod(
@@ -566,22 +566,30 @@ export async function execCpToPod(
   const delay = 1000
   for (let i = 0; i < attempts; i++) {
     try {
-      const want = await localCalculateOutputHashSorted([
-        'sh',
-        '-c',
-        listDirAllCommand(runnerPath)
-      ])
+      const { hash: want, lines: wantLines } =
+        await localCalculateOutputHashSorted([
+          'sh',
+          '-c',
+          listDirAllCommand(runnerPath)
+        ])
 
-      const got = await execCalculateOutputHashSorted(
-        podName,
-        JOB_CONTAINER_NAME,
-        ['sh', '-c', listDirAllCommand(containerPath)]
-      )
+      const { hash: got, lines: gotLines } =
+        await execCalculateOutputHashSorted(
+          podName,
+          JOB_CONTAINER_NAME,
+          ['sh', '-c', listDirAllCommand(containerPath)]
+        )
 
       if (got !== want) {
+        const wantSet = new Set(wantLines)
+        const gotSet = new Set(gotLines)
+        const onlyInWant = wantLines.filter(l => !gotSet.has(l))
+        const onlyInGot = gotLines.filter(l => !wantSet.has(l))
         core.debug(
           `The hash of the directory does not match the expected value; want='${want}' got='${got}'`
         )
+        core.debug(`only in runner (want): ${JSON.stringify(onlyInWant)}`)
+        core.debug(`only in pod (got):     ${JSON.stringify(onlyInGot)}`)
         await sleep(delay)
         continue
       }
@@ -669,22 +677,30 @@ export async function execCpFromPod(
   const delay = 1000
   for (let i = 0; i < attempts; i++) {
     try {
-      const want = await execCalculateOutputHashSorted(
-        podName,
-        JOB_CONTAINER_NAME,
-        ['sh', '-c', listDirAllCommand(containerPath)]
-      )
+      const { hash: want, lines: wantLines } =
+        await execCalculateOutputHashSorted(
+          podName,
+          JOB_CONTAINER_NAME,
+          ['sh', '-c', listDirAllCommand(containerPath)]
+        )
 
-      const got = await localCalculateOutputHashSorted([
-        'sh',
-        '-c',
-        listDirAllCommand(targetRunnerPath)
-      ])
+      const { hash: got, lines: gotLines } =
+        await localCalculateOutputHashSorted([
+          'sh',
+          '-c',
+          listDirAllCommand(targetRunnerPath)
+        ])
 
       if (got !== want) {
+        const wantSet = new Set(wantLines)
+        const gotSet = new Set(gotLines)
+        const onlyInWant = wantLines.filter(l => !gotSet.has(l))
+        const onlyInGot = gotLines.filter(l => !wantSet.has(l))
         core.debug(
           `The hash of the directory does not match the expected value; want='${want}' got='${got}'`
         )
+        core.debug(`only in pod (want):    ${JSON.stringify(onlyInWant)}`)
+        core.debug(`only in runner (got):  ${JSON.stringify(onlyInGot)}`)
         await sleep(delay)
         continue
       }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -581,15 +581,32 @@ export async function execCpToPod(
         )
 
       if (got !== want) {
-        const wantSet = new Set(wantLines)
-        const gotSet = new Set(gotLines)
-        const onlyInWant = wantLines.filter(l => !gotSet.has(l))
-        const onlyInGot = gotLines.filter(l => !wantSet.has(l))
         core.debug(
-          `The hash of the directory does not match the expected value; want='${want}' got='${got}'`
+          `[cpToPod hash mismatch attempt ${i + 1}/${attempts}] want='${want}' got='${got}'`
         )
-        core.debug(`only in runner (want): ${JSON.stringify(onlyInWant)}`)
-        core.debug(`only in pod (got):     ${JSON.stringify(onlyInGot)}`)
+        core.debug(
+          `[cpToPod] runner file count=${wantLines.length} pod file count=${gotLines.length}`
+        )
+        const wantMap = new Map(
+          wantLines.map(l => [l.replace(/^\d+ /, ''), l.split(' ')[0]])
+        )
+        const gotMap = new Map(
+          gotLines.map(l => [l.replace(/^\d+ /, ''), l.split(' ')[0]])
+        )
+        const onlyInWant = wantLines.filter(l => !gotMap.has(l.replace(/^\d+ /, '')))
+        const onlyInGot = gotLines.filter(l => !wantMap.has(l.replace(/^\d+ /, '')))
+        const sizeDiff = wantLines
+          .filter(l => {
+            const name = l.replace(/^\d+ /, '')
+            return gotMap.has(name) && gotMap.get(name) !== wantMap.get(name)
+          })
+          .map(l => {
+            const name = l.replace(/^\d+ /, '')
+            return `${name}: runner=${wantMap.get(name)} pod=${gotMap.get(name)}`
+          })
+        core.debug(`[cpToPod] only in runner: ${JSON.stringify(onlyInWant)}`)
+        core.debug(`[cpToPod] only in pod:    ${JSON.stringify(onlyInGot)}`)
+        core.debug(`[cpToPod] size mismatch:  ${JSON.stringify(sizeDiff)}`)
         await sleep(delay)
         continue
       }
@@ -692,15 +709,32 @@ export async function execCpFromPod(
         ])
 
       if (got !== want) {
-        const wantSet = new Set(wantLines)
-        const gotSet = new Set(gotLines)
-        const onlyInWant = wantLines.filter(l => !gotSet.has(l))
-        const onlyInGot = gotLines.filter(l => !wantSet.has(l))
         core.debug(
-          `The hash of the directory does not match the expected value; want='${want}' got='${got}'`
+          `[cpFromPod hash mismatch attempt ${i + 1}/${attempts}] want='${want}' got='${got}'`
         )
-        core.debug(`only in pod (want):    ${JSON.stringify(onlyInWant)}`)
-        core.debug(`only in runner (got):  ${JSON.stringify(onlyInGot)}`)
+        core.debug(
+          `[cpFromPod] pod file count=${wantLines.length} runner file count=${gotLines.length}`
+        )
+        const wantMap = new Map(
+          wantLines.map(l => [l.replace(/^\d+ /, ''), l.split(' ')[0]])
+        )
+        const gotMap = new Map(
+          gotLines.map(l => [l.replace(/^\d+ /, ''), l.split(' ')[0]])
+        )
+        const onlyInWant = wantLines.filter(l => !gotMap.has(l.replace(/^\d+ /, '')))
+        const onlyInGot = gotLines.filter(l => !wantMap.has(l.replace(/^\d+ /, '')))
+        const sizeDiff = wantLines
+          .filter(l => {
+            const name = l.replace(/^\d+ /, '')
+            return gotMap.has(name) && gotMap.get(name) !== wantMap.get(name)
+          })
+          .map(l => {
+            const name = l.replace(/^\d+ /, '')
+            return `${name}: pod=${wantMap.get(name)} runner=${gotMap.get(name)}`
+          })
+        core.debug(`[cpFromPod] only in pod:    ${JSON.stringify(onlyInWant)}`)
+        core.debug(`[cpFromPod] only in runner: ${JSON.stringify(onlyInGot)}`)
+        core.debug(`[cpFromPod] size mismatch:  ${JSON.stringify(sizeDiff)}`)
         await sleep(delay)
         continue
       }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -656,6 +656,12 @@ export async function execCpFromPod(
       const errStream = new WritableStreamBuffer()
 
       await new Promise((resolve, reject) => {
+        // Resolve only after writerStream finishes flushing to disk.
+        // The k8s status callback fires when the pod-side tar process exits,
+        // but tar-fs may still be writing buffered data to the local filesystem.
+        // Waiting for 'finish' ensures all files are on disk before hash check.
+        writerStream.on('finish', resolve)
+        writerStream.on('error', reject)
         exec
           .exec(
             namespace(),
@@ -666,7 +672,7 @@ export async function execCpFromPod(
             errStream,
             null,
             false,
-            async status => {
+            async _status => {
               if (errStream.size()) {
                 reject(
                   new Error(
@@ -674,7 +680,6 @@ export async function execCpFromPod(
                   )
                 )
               }
-              resolve(status)
             }
           )
           .catch(e => reject(e))

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -521,7 +521,7 @@ export async function execCpToPod(
         `tar xf - --no-same-owner -C ${shlex.quote(containerPath)} 2>/dev/null; ` +
           `find ${shlex.quote(containerPath)} -type f -exec chmod u+rw {} \\; 2>/dev/null; ` +
           `find ${shlex.quote(containerPath)} -type d -exec chmod u+rwx {} \\; 2>/dev/null; ` +
-          `sync`
+          `sync 2>/dev/null || true`
       ]
       const readStream = tar.pack(runnerPath)
       const errStream = new WritableStreamBuffer()
@@ -696,12 +696,6 @@ export async function execCpFromPod(
       await sleep(1000)
     }
   }
-
-  await new Promise<void>(resolve => {
-    const child = spawn('sync', [], { stdio: 'ignore' })
-    child.on('close', () => resolve())
-    child.on('error', () => resolve())
-  })
 
   let attempts = 15
   const delay = 1000

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -520,7 +520,8 @@ export async function execCpToPod(
         '-c',
         `tar xf - --no-same-owner -C ${shlex.quote(containerPath)} 2>/dev/null; ` +
           `find ${shlex.quote(containerPath)} -type f -exec chmod u+rw {} \\; 2>/dev/null; ` +
-          `find ${shlex.quote(containerPath)} -type d -exec chmod u+rwx {} \\; 2>/dev/null`
+          `find ${shlex.quote(containerPath)} -type d -exec chmod u+rwx {} \\; 2>/dev/null; ` +
+          `sync`
       ]
       const readStream = tar.pack(runnerPath)
       const errStream = new WritableStreamBuffer()
@@ -657,6 +658,12 @@ export async function execCpFromPod(
       await sleep(1000)
     }
   }
+
+  await new Promise<void>(resolve => {
+    const child = spawn('sync', [], { stdio: 'ignore' })
+    child.on('close', () => resolve())
+    child.on('error', () => resolve())
+  })
 
   let attempts = 15
   const delay = 1000


### PR DESCRIPTION
## 描述
<!-- 请简要描述这个 PR 的目的和变更内容 -->
1. PostCheckout复制时不匹配反复重试

┌──────────────────────────────────────────────────────────────────┐
│  checkout 在 pod 内删除了 credentials                                                                                                             │
│       ↓                                                          │
│  execCpFromPod 把 pod/_temp（23文件）tar 解压到 runner/_temp      │
│       ↓                                                          │
│  tar.extract() 不清空目标目录                                     │
│       ↓                                                          │
│  runner/_temp 仍保留旧 credentials（24文件）                      │
│       ↓                                                          │
│  hash(pod) ≠ hash(runner)，15次重试全部失败                       │
└──────────────────────────────────────────────────────────────────┘
pod 是数据的权威来源，runner 本地是 pod 状态的镜像。\
先清空再同步，保证 runner 和 pod 完全一致，不受历史残留文件干扰。

2. 清空目录后暴露的新问题: tar 写入未完成时 hash check 已开始
<img width="688" height="377" alt="image" src="https://github.com/user-attachments/assets/2748d3a3-c61e-4afd-b1ee-af05a4e52c1b" />
改为监听 tar-fs stream 的 `finish` 事件，确保所有文件写入磁盘后再 resolve


## 相关 Issue
<!-- 链接到相关的 issue，使用关键字，如：resolve https://github.com/opensourceways/{repo}/issues/2 -->
resolve https://github.com/opensourceways/backlog/issues/1203

## 变更类型
<!-- 请勾选适用的变更类型 -->
- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
