### PR TITLE
fix: add null check for jobPod in runScriptStep to handle pod creation failures

### DIFF
--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -31,6 +31,13 @@ export async function runScriptStep(
   args: RunScriptStepArgs,
   state
 ): Promise<void> {
+  // Validate that pod was created successfully (prepareJob succeeded)
+  if (!state?.jobPod) {
+    throw new Error(
+      'jobPod must be set - ensure prepareJob completed successfully before running script steps'
+    )
+  }
+
   // Write the entrypoint first. This will be later coppied to the workflow pod
   const { entryPoint, entryPointArgs, environmentVariables } = args
   const { containerPath, runnerPath } = writeRunScript(

--- a/packages/k8s/tests/run-script-step-unit-test.ts
+++ b/packages/k8s/tests/run-script-step-unit-test.ts
@@ -105,4 +105,18 @@ describe('runScriptStep error classification', () => {
       /failed to run script step.*websocket connection dropped/
     )
   })
+
+  it('should throw error when state.jobPod is null (pod creation failed)', async () => {
+    const nullState = { jobPod: null }
+    await expect(runScriptStep(makeArgs(), nullState)).rejects.toThrow(
+      /jobPod must be set/
+    )
+  })
+
+  it('should throw error when state.jobPod is undefined (pod creation failed)', async () => {
+    const undefinedState = {}
+    await expect(runScriptStep(makeArgs(), undefinedState)).rejects.toThrow(
+      /jobPod must be set/
+    )
+  })
 })


### PR DESCRIPTION


## 描述
<!-- 请简要描述这个 PR 的目的和变更内容 -->
Daily Enumerate Tests (Ascend NPU)日构建pod 创建失败，修复问题
  - xk2b5：prepareJob 异常后流程终止，未到 runScriptStep (最初的问题没有日志难以定位)
  - cjmd9：继续执行 runScriptStep，触发 null 引用 bug (后面复现问题，但有所不同)

当prepareJob失败时（pod创建/启动失败），state.jobPod未初始化。后续的runScriptStep尝试访问null.jobPod，导致TypeError：无法读取null的属性。

When prepareJob fails (pod creation/startup fails), state.jobPod is not initialized. Subsequent runScriptStep attempts to access null.jobPod, causing TypeError: Cannot read properties of null.

This fix adds early validation to throw a clear error when jobPod is null, indicating that prepareJob failed. This prevents cryptic null reference errors and improves debugging.

- Add null/undefined check at runScriptStep entry point
- Add test cases for null and undefined jobPod scenarios
- Error message clearly indicates prepareJob dependency

## 相关 Issue
<!-- 链接到相关的 issue，使用关键字，如：resolve https://github.com/opensourceways/{repo}/issues/2 -->
resolve https://github.com/opensourceways/backlog/issues/1350

## 变更类型
<!-- 请勾选适用的变更类型 -->
- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
