### PR TITLE
fix(k8s): 统一错误格式并优化提示信息unify error format and surface terminated container hints

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -126,9 +126,17 @@ export async function prepareJob(
     } catch {
       // Parsing failed — fall through and show the raw string
     }
-    throw new Error(
-      `failed to create job pod:\n  ✗ ${detail}\n${'─'.repeat(60)}\n  → Pod spec was rejected by the k8s API. Check:\n    - resources.requests does not exceed resources.limits\n    - volumeMounts reference a volume defined in spec.volumes\n    - envFrom / valueFrom reference existing Secrets / ConfigMaps\n    - Field types match the k8s schema (kubectl explain pod.spec.containers)`
-    )
+    const errorMessage = [
+      'failed to create job pod:',
+      `  ✗ ${detail}`,
+      '-'.repeat(60),
+      '  → Pod spec was rejected by the k8s API. Check:',
+      '    - resources.requests does not exceed resources.limits',
+      '    - volumeMounts reference a volume defined in spec.volumes',
+      '    - envFrom / valueFrom reference existing Secrets / ConfigMaps',
+      '    - Field types match the k8s schema (kubectl explain pod.spec.containers)'
+    ].join('\n')
+    throw new Error(errorMessage)
   }
 
   if (!createdPod?.metadata?.name) {

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -126,7 +126,9 @@ export async function prepareJob(
     } catch {
       // Parsing failed — fall through and show the raw string
     }
-    throw new Error(`failed to create job pod:\n  ${detail}`)
+    throw new Error(
+      `failed to create job pod:\n  ✗ ${detail}\n${'─'.repeat(60)}\n  → Pod spec was rejected by the k8s API. Check:\n    - resources.requests does not exceed resources.limits\n    - volumeMounts reference a volume defined in spec.volumes\n    - envFrom / valueFrom reference existing Secrets / ConfigMaps\n    - Field types match the k8s schema (kubectl explain pod.spec.containers)`
+    )
   }
 
   if (!createdPod?.metadata?.name) {

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -173,7 +173,7 @@ async function classifyScriptError(
   exitCode: number,
   tailOutput: string
 ): Promise<string> {
-  const sep = '─'.repeat(60)
+  const sep = '-'.repeat(60)
   const errors: string[] = [`  ✗ exit code: ${exitCode}`]
   const sections: string[] = []
 

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -9,7 +9,7 @@ import { dirname } from 'path'
 import * as shlex from 'shlex'
 
 function formatScriptError(exitCode: number, tailOutput: string): string {
-  const sep = '─'.repeat(60)
+  const sep = '-'.repeat(60)
   const errors = [
     `  ✗ exit code: ${exitCode}`,
     `  → your script exited with a non-zero code; please check your script for errors`

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -1355,6 +1355,8 @@ export async function checkUnrecoverableErrors(
 ): Promise<string[]> {
   // Deterministic terminal errors on a container (e.g. ImagePullBackOff).
   const containerErrors = getContainerErrors(pod)
+  // Terminated container errors (e.g. OOMKilled, non-zero exit) with hints.
+  const terminatedErrors = getContainerTerminatedErrors(pod)
   // Best-effort: returns [] when the optional events RBAC permission is absent.
   const eventErrors = await getPodEventErrors(podName)
   // Conditions are set near-instantly by the scheduler while events may take
@@ -1363,7 +1365,7 @@ export async function checkUnrecoverableErrors(
   const conditionErrors = getPodConditionErrors(pod).filter(
     c => !eventErrors.some(e => e.includes('FailedScheduling') && c.includes('Unschedulable'))
   )
-  return [...containerErrors, ...eventErrors, ...conditionErrors]
+  return [...containerErrors, ...terminatedErrors, ...eventErrors, ...conditionErrors]
 }
 
 export async function waitForPodPhases(
@@ -1404,9 +1406,18 @@ export async function waitForPodPhases(
     }
 
     // The pod reached a phase we are not willing to keep waiting on
-    // (a terminal/unhealthy phase). Attach full diagnostics and stop.
+    // (a terminal/unhealthy phase). First check for unrecoverable
+    // container-level errors (e.g. OOMKilled, non-zero exit) so they are
+    // reported with actionable hints. Fall back to the generic "is unhealthy"
+    // message when no specific error is found.
     if (!backOffPhases.has(phase)) {
+      const errors = await checkUnrecoverableErrors(pod, podName)
       const details = await describePodFailure(podName)
+      if (errors.length > 0) {
+        throw new Error(
+          `Pod ${podName} has unrecoverable errors:\n${errors.join('\n')}\n${'─'.repeat(60)}\n${details}`
+        )
+      }
       throw new Error(
         `Pod ${podName} is unhealthy (phase: ${phase})\n${'─'.repeat(60)}\n${details}`
       )

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -1395,7 +1395,7 @@ export async function waitForPodPhases(
         throw new Error(
           `Pod ${podName} timed out after ${maxTimeSeconds}s (pod read failed: ${
             err instanceof Error ? err.message : String(err)
-          })\n${'─'.repeat(60)}\n(pod was unreadable; no further diagnostics available)`
+          })\n${'-'.repeat(60)}\n(pod was unreadable; no further diagnostics available)`
         )
       }
       continue
@@ -1415,11 +1415,11 @@ export async function waitForPodPhases(
       const details = await describePodFailure(podName)
       if (errors.length > 0) {
         throw new Error(
-          `Pod ${podName} has unrecoverable errors:\n${errors.join('\n')}\n${'─'.repeat(60)}\n${details}`
+          `Pod ${podName} has unrecoverable errors:\n${errors.join('\n')}\n${'-'.repeat(60)}\n${details}`
         )
       }
       throw new Error(
-        `Pod ${podName} is unhealthy (phase: ${phase})\n${'─'.repeat(60)}\n${details}`
+        `Pod ${podName} is unhealthy (phase: ${phase})\n${'-'.repeat(60)}\n${details}`
       )
     }
 
@@ -1430,7 +1430,7 @@ export async function waitForPodPhases(
     if (errors.length > 0) {
       const details = await describePodFailure(podName)
       throw new Error(
-        `Pod ${podName} has unrecoverable errors:\n${errors.join('\n')}\n${'─'.repeat(60)}\n${details}`
+        `Pod ${podName} has unrecoverable errors:\n${errors.join('\n')}\n${'-'.repeat(60)}\n${details}`
       )
     }
 
@@ -1442,7 +1442,7 @@ export async function waitForPodPhases(
       // can see WHY the pod never became ready.
       const details = await describePodFailure(podName)
       throw new Error(
-        `Pod ${podName} timed out after ${maxTimeSeconds}s (phase: ${phase})\n${'─'.repeat(60)}\n${details}`
+        `Pod ${podName} timed out after ${maxTimeSeconds}s (phase: ${phase})\n${'-'.repeat(60)}\n${details}`
       )
     }
   }


### PR DESCRIPTION


## 描述
<!-- 请简要描述这个 PR 的目的和变更内容 -->
统一错误格式并优化提示信息
unify error format and surface terminated container hints
- prepare-job: format 422 pod creation errors with consistent header, separator, and actionable troubleshooting hints matching the unrecoverable-errors output style.
- k8s/index.ts: include getContainerTerminatedErrors in checkUnrecoverableErrors so OOMKilled / non-zero exit failures are reported with their hints during waitForPodPhases. When phase=Failed and terminated errors exist, the error now uses the "has unrecoverable errors" format instead of the generic "is unhealthy" message.

## 相关 Issue
<!-- 链接到相关的 issue，使用关键字，如：resolve https://github.com/opensourceways/{repo}/issues/2 -->
resolve https://github.com/opensourceways/backlog/issues/1203

## 变更类型
<!-- 请勾选适用的变更类型 -->
- [ ] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [x] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
