### PR TITLE
fix(k8s): grace period for image pull failures instead of instant fail

### DIFF
--- a/packages/k8s/README.md
+++ b/packages/k8s/README.md
@@ -47,10 +47,16 @@ rules:
     - `ACTIONS_RUNNER_K8S_UNRECOVERABLE_WAITING_REASONS` — comma-separated list of
       extra container `waiting` reasons that should be treated as deterministic
       terminal failures (fail fast instead of waiting for the timeout). These are
-      *added* to the built-ins (`ImagePullBackOff`, `ErrImagePull`,
-      `InvalidImageName`, `CreateContainerConfigError`, `CreateContainerError`);
+      *added* to the built-ins (`InvalidImageName`, `CreateContainerConfigError`);
       the built-ins can never be removed. Use with care — only list reasons that
       are truly unrecoverable for your workloads (e.g. `CrashLoopBackOff`).
+    - `ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS` — how long `ImagePullBackOff`
+      / `ErrImagePull` may persist before the hook fails the job (default `300`,
+      i.e. 5 minutes). The pod is given this window to self-heal, e.g. during a
+      transient network outage. Permanent image errors (bad tag, invalid
+      credentials, missing repository) are detected from the waiting message and
+      still fail immediately. Set to `0` to fail as soon as the pull failure is
+      observed (the previous behavior).
 
 
 ## Limitations

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -324,8 +324,14 @@ export async function execPodStepWithOutput(
   }
 
   const flushPending = () => {
-    if (pendingOut) { push(pendingOut); pendingOut = '' }
-    if (pendingErr) { push(pendingErr); pendingErr = '' }
+    if (pendingOut) {
+      push(pendingOut)
+      pendingOut = ''
+    }
+    if (pendingErr) {
+      push(pendingErr)
+      pendingErr = ''
+    }
   }
 
   const capture = new stream.Writable({
@@ -574,11 +580,11 @@ export async function execCpToPod(
         ])
 
       const { hash: got, lines: gotLines } =
-        await execCalculateOutputHashSorted(
-          podName,
-          JOB_CONTAINER_NAME,
-          ['sh', '-c', listDirAllCommand(containerPath)]
-        )
+        await execCalculateOutputHashSorted(podName, JOB_CONTAINER_NAME, [
+          'sh',
+          '-c',
+          listDirAllCommand(containerPath)
+        ])
 
       if (got !== want) {
         core.debug(
@@ -593,8 +599,12 @@ export async function execCpToPod(
         const gotMap = new Map(
           gotLines.map(l => [l.replace(/^\d+ /, ''), l.split(' ')[0]])
         )
-        const onlyInWant = wantLines.filter(l => !gotMap.has(l.replace(/^\d+ /, '')))
-        const onlyInGot = gotLines.filter(l => !wantMap.has(l.replace(/^\d+ /, '')))
+        const onlyInWant = wantLines.filter(
+          l => !gotMap.has(l.replace(/^\d+ /, ''))
+        )
+        const onlyInGot = gotLines.filter(
+          l => !wantMap.has(l.replace(/^\d+ /, ''))
+        )
         const sizeDiff = wantLines
           .filter(l => {
             const name = l.replace(/^\d+ /, '')
@@ -702,11 +712,11 @@ export async function execCpFromPod(
   for (let i = 0; i < attempts; i++) {
     try {
       const { hash: want, lines: wantLines } =
-        await execCalculateOutputHashSorted(
-          podName,
-          JOB_CONTAINER_NAME,
-          ['sh', '-c', listDirAllCommand(containerPath)]
-        )
+        await execCalculateOutputHashSorted(podName, JOB_CONTAINER_NAME, [
+          'sh',
+          '-c',
+          listDirAllCommand(containerPath)
+        ])
 
       const { hash: got, lines: gotLines } =
         await localCalculateOutputHashSorted([
@@ -728,8 +738,12 @@ export async function execCpFromPod(
         const gotMap = new Map(
           gotLines.map(l => [l.replace(/^\d+ /, ''), l.split(' ')[0]])
         )
-        const onlyInWant = wantLines.filter(l => !gotMap.has(l.replace(/^\d+ /, '')))
-        const onlyInGot = gotLines.filter(l => !wantMap.has(l.replace(/^\d+ /, '')))
+        const onlyInWant = wantLines.filter(
+          l => !gotMap.has(l.replace(/^\d+ /, ''))
+        )
+        const onlyInGot = gotLines.filter(
+          l => !wantMap.has(l.replace(/^\d+ /, ''))
+        )
         const sizeDiff = wantLines
           .filter(l => {
             const name = l.replace(/^\d+ /, '')
@@ -862,21 +876,81 @@ export async function pruneSecrets(): Promise<void> {
 }
 
 export const UNRECOVERABLE_WAITING_REASONS = new Set([
-  // k8s has already retried image pull multiple times with exponential backoff.
-  // ErrImagePull is excluded: it fires on the first failure (could be a transient
-  // TLS timeout or network blip) and k8s will naturally promote it to
-  // ImagePullBackOff after a moment. Fast-failing on ErrImagePull would kill
-  // jobs that would have succeeded on the next pull attempt.
-  'ImagePullBackOff',
   // Image name is syntactically invalid — cannot self-heal without a config fix.
   'InvalidImageName',
   // Container spec is invalid (bad env vars, resource limits, securityContext) —
   // cannot self-heal without a config fix.
-  'CreateContainerConfigError',
+  'CreateContainerConfigError'
   // CreateContainerError is excluded: it is sometimes emitted transiently by the
   // container runtime (e.g. during a node-level runtime restart). It can
   // self-resolve on the next kubelet retry cycle.
+  //
+  // ImagePullBackOff and ErrImagePull are also excluded from this set. k8s
+  // promotes to ImagePullBackOff from the second pull attempt, so fast-failing
+  // on it would kill jobs during a transient network outage. They are instead
+  // handled by the image-pull grace window in waitForPodPhases (see
+  // IMAGE_PULL_WAITING_REASONS / evaluateImagePullFailures): the hook waits a
+  // bounded grace period for the pull to self-heal and only then fails, unless
+  // the waiting message positively identifies a permanent cause.
 ])
+
+// Waiting reasons that indicate the container image could not be pulled yet.
+// Unlike UNRECOVERABLE_WAITING_REASONS these are NOT failed instantly: a pull
+// can be stuck transiently (DNS/TLS/registry outage) and self-heal on a later
+// kubelet retry. waitForPodPhases gives them a bounded grace period (see
+// getImagePullGraceMs / evaluateImagePullFailures) and only fails once that
+// grace is exceeded without recovery — or immediately when the waiting message
+// positively identifies a permanent cause (see PERMANENT_IMAGE_PULL_PATTERNS).
+export const IMAGE_PULL_WAITING_REASONS = new Set([
+  'ImagePullBackOff',
+  'ErrImagePull'
+])
+
+// Waiting messages that POSITIVELY IDENTIFY a permanent image-pull failure that
+// will not self-heal even if the network recovers (wrong image/tag, missing
+// registry repository, invalid credentials). When one of these matches,
+// fast-fail immediately, skipping the grace period. Anything else (network /
+// TLS / timeout errors) is treated as transient and given the grace window.
+//
+// Permanent examples (WILL fast-fail immediately):
+//   "pull access denied for nope/nonexistent, repository does not exist or may require 'docker login'"
+//   "manifest for nope:latest not found"
+//   "unauthorized: authentication required"
+//
+// Transient examples (grace window applies):
+//   "dial tcp 10.0.0.1:443: connect: connection refused"
+//   "TLS handshake timeout"
+//   "failed to resolve reference: ... i/o timeout"
+export const PERMANENT_IMAGE_PULL_PATTERNS: readonly RegExp[] = [
+  /manifest .*not found/i,
+  /pull access denied/i,
+  /unauthorized/i,
+  /repository does not exist/i,
+  /image not known/i,
+  /denied: requested access/i,
+  /no such image/i
+]
+
+export const DEFAULT_IMAGE_PULL_GRACE_MS = 5 * 60 * 1000 // 5 min
+
+// How long an image-pull failure may persist before the hook gives up. Reads
+// ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS (default 300). A value of 0
+// restores the old behavior: fail as soon as the pull failure is observed.
+export function getImagePullGraceMs(): number {
+  const envGraceSeconds =
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS']
+  if (!envGraceSeconds) {
+    return DEFAULT_IMAGE_PULL_GRACE_MS
+  }
+  const graceSeconds = parseInt(envGraceSeconds, 10)
+  if (Number.isNaN(graceSeconds) || graceSeconds < 0) {
+    core.warning(
+      `Image pull grace is invalid ("${envGraceSeconds}"): use an int >= 0, falling back to ${DEFAULT_IMAGE_PULL_GRACE_MS / 1000}s`
+    )
+    return DEFAULT_IMAGE_PULL_GRACE_MS
+  }
+  return graceSeconds * 1000
+}
 
 // Pod *event* reasons (from the event stream, not container status) that
 // indicate a permanent failure the pod will never recover from on its own.
@@ -930,7 +1004,7 @@ export const PERMANENT_SCHEDULING_PATTERNS: readonly RegExp[] = [
   // PVC referenced in the pod spec does not exist in the namespace. The
   // scheduler refuses to place the pod until the PVC is created. The workflow
   // job spec is wrong — it won't self-resolve.
-  /persistentvolumeclaim "[^"]+" not found/i,
+  /persistentvolumeclaim "[^"]+" not found/i
 ]
 
 export const UNRECOVERABLE_TERMINATED_REASONS = new Set([
@@ -981,7 +1055,8 @@ export function getUnrecoverableEventReasons(): Set<string> {
 }
 
 export function getUnrecoverableTerminatedReasons(): Set<string> {
-  const extra = process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS']
+  const extra =
+    process.env['ACTIONS_RUNNER_K8S_UNRECOVERABLE_TERMINATED_REASONS']
   if (!extra) {
     return UNRECOVERABLE_TERMINATED_REASONS
   }
@@ -1001,7 +1076,9 @@ export function getUnrecoverableTerminatedReasons(): Set<string> {
 //   - absent/empty messages   → unknown, assume transient
 //   - resource shortages      → Insufficient cpu/memory/gpu/etc.
 //   - any unrecognised format → unknown, assume transient
-export function isPermanentSchedulingFailure(message: string | undefined): boolean {
+export function isPermanentSchedulingFailure(
+  message: string | undefined
+): boolean {
   if (!message) return false
   return getPermanentSchedulingPatterns().some(p => p.test(message))
 }
@@ -1046,7 +1123,15 @@ function getWaitingReasonHint(reason: string): string {
         `    - Image name and tag are correct and exist in the registry`,
         `    - If private registry: imagePullSecret is configured and credentials are valid`,
         `    - Network connectivity from the node to the registry (DNS, firewall, proxy, TLS)`,
-        `    Run: kubectl describe pod <pod> | grep -A10 "Events"`,
+        `    Run: kubectl describe pod <pod> | grep -A10 "Events"`
+      ].join('\n')
+    case 'ErrImagePull':
+      return [
+        `  → Image pull failed and did not recover within the grace period. Check:`,
+        `    - Image name and tag are correct and exist in the registry`,
+        `    - If private registry: imagePullSecret is configured and credentials are valid`,
+        `    - Network connectivity from the node to the registry (DNS, firewall, proxy, TLS)`,
+        `    Run: kubectl describe pod <pod> | grep -A10 "Events"`
       ].join('\n')
     case 'InvalidImageName':
       return `  → Image name is malformed. Check the workflow/job container image configuration.`
@@ -1076,7 +1161,64 @@ export function getContainerErrors(pod: k8s.V1Pod): string[] {
   return errors
 }
 
-export function getTerminatedReasonHint(reason: string, exitCode: number | undefined): string {
+// Tracks, per container, the first time it was observed in an image-pull-failure
+// waiting state (ImagePullBackOff / ErrImagePull) and reports an error for any
+// container whose failure has either (a) persisted continuously beyond graceMs,
+// or (b) a waiting message matching PERMANENT_IMAGE_PULL_PATTERNS. Containers
+// that recover (leave the image-pull-failure state) have their tracking entry
+// cleared, so a later pull failure starts a fresh grace window. `firstSeen` is
+// mutated in place and must be owned by the caller (one per waitForPodPhases
+// loop). `now` is injected for testability.
+export function evaluateImagePullFailures(
+  pod: k8s.V1Pod,
+  firstSeen: Map<string, number>,
+  graceMs: number,
+  now: number
+): string[] {
+  const allStatuses = [
+    ...(pod.status?.initContainerStatuses ?? []),
+    ...(pod.status?.containerStatuses ?? [])
+  ]
+  const errors: string[] = []
+  const currentlyFailing = new Set<string>()
+  for (const cs of allStatuses) {
+    const waiting = cs.state?.waiting
+    if (!waiting?.reason || !IMAGE_PULL_WAITING_REASONS.has(waiting.reason)) {
+      continue
+    }
+    currentlyFailing.add(cs.name)
+    if (!firstSeen.has(cs.name)) {
+      firstSeen.set(cs.name, now)
+    }
+    const startedAt = firstSeen.get(cs.name) as number
+    const message = waiting.message ?? ''
+    const permanent = PERMANENT_IMAGE_PULL_PATTERNS.some(p => p.test(message))
+    const elapsed = now - startedAt
+    if (!permanent && elapsed < graceMs) {
+      continue
+    }
+    const qualifier = permanent
+      ? '(permanent image error)'
+      : `(failed for ${Math.round(elapsed / 1000)}s, exceeding the ${Math.round(graceMs / 1000)}s grace period)`
+    const reason = `  ✗ container "${cs.name}": ${waiting.reason} ${qualifier}`
+    const detail = message ? `\n    ${message}` : ''
+    const hint = `\n${getWaitingReasonHint(waiting.reason)}`
+    errors.push(`${reason}${detail}${hint}`)
+  }
+  // Drop tracking for containers no longer in an image-pull-failure state so a
+  // later failure gets a fresh grace window.
+  for (const name of Array.from(firstSeen.keys())) {
+    if (!currentlyFailing.has(name)) {
+      firstSeen.delete(name)
+    }
+  }
+  return errors
+}
+
+export function getTerminatedReasonHint(
+  reason: string,
+  exitCode: number | undefined
+): string {
   if (reason === 'OOMKilled') {
     return `  → Container exceeded its memory limit and was killed by the OOM killer.\n    Increase the memory limit in the job spec or reduce memory usage in the script.`
   }
@@ -1126,21 +1268,21 @@ function getEventReasonHint(reason: string): string {
         `  → A volume could not be mounted. Check:`,
         `    - PVC is bound (kubectl get pvc)`,
         `    - Secret/ConfigMap referenced in the volume exists`,
-        `    - hostPath directories exist on the scheduled node`,
+        `    - hostPath directories exist on the scheduled node`
       ].join('\n')
     case 'FailedBinding':
       return [
         `  → A PVC could not be bound to a PV. Check:`,
         `    - StorageClass exists and has a provisioner`,
         `    - Sufficient capacity is available`,
-        `    - Access mode (ReadWriteOnce/ReadWriteMany) matches available PVs`,
+        `    - Access mode (ReadWriteOnce/ReadWriteMany) matches available PVs`
       ].join('\n')
     case 'FailedScheduling':
       return [
         `  → Pod cannot be scheduled due to a permanent configuration error. Check:`,
         `    - nodeSelector / nodeAffinity labels match at least one node`,
         `    - All tolerations are present for node taints`,
-        `    - PVCs referenced in the pod spec exist in the namespace`,
+        `    - PVCs referenced in the pod spec exist in the namespace`
       ].join('\n')
     default:
       return `  → Check pod events with: kubectl describe pod <pod>`
@@ -1180,13 +1322,20 @@ export async function getPodEventErrors(podName: string): Promise<string[]> {
   const errors: string[] = []
   const seenReasons = new Set<string>()
   for (const e of items) {
-    if (e.type !== 'Warning' || !e.reason || !unrecoverableReasons.has(e.reason)) {
+    if (
+      e.type !== 'Warning' ||
+      !e.reason ||
+      !unrecoverableReasons.has(e.reason)
+    ) {
       continue
     }
     // FailedScheduling: only fast-fail when the message positively matches a
     // known-permanent config error. Resource shortages and unknown messages
     // are treated as transient — let the pod keep queuing.
-    if (e.reason === 'FailedScheduling' && !isPermanentSchedulingFailure(e.message)) {
+    if (
+      e.reason === 'FailedScheduling' &&
+      !isPermanentSchedulingFailure(e.message)
+    ) {
       core.debug(
         `[fast-fail] Skipping FailedScheduling (not a recognised permanent error): ${
           e.message ?? '(no message)'
@@ -1256,11 +1405,16 @@ export async function describePodFailure(podName: string): Promise<string> {
   for (const cs of allStatuses) {
     const waiting = cs.state?.waiting
     if (waiting?.reason) {
-      // Skip reasons already surfaced by getContainerErrors() in the caller's
-      // first line to avoid printing the same error twice.
-      if (!unrecoverableReasons.has(waiting.reason)) {
+      // Skip reasons already surfaced by getContainerErrors() or the image-pull
+      // grace fast-fail to avoid printing the same error twice.
+      if (
+        !unrecoverableReasons.has(waiting.reason) &&
+        !IMAGE_PULL_WAITING_REASONS.has(waiting.reason)
+      ) {
         const msg = waiting.message ? `\n    ${waiting.message}` : ''
-        containerLines.push(`  ✗ container "${cs.name}" waiting: ${waiting.reason}${msg}`)
+        containerLines.push(
+          `  ✗ container "${cs.name}" waiting: ${waiting.reason}${msg}`
+        )
       }
     }
     const terminated = cs.state?.terminated
@@ -1363,9 +1517,17 @@ export async function checkUnrecoverableErrors(
   // a few extra seconds to propagate, so always run the check. Deduplicate
   // against events so the same FailedScheduling isn't printed twice.
   const conditionErrors = getPodConditionErrors(pod).filter(
-    c => !eventErrors.some(e => e.includes('FailedScheduling') && c.includes('Unschedulable'))
+    c =>
+      !eventErrors.some(
+        e => e.includes('FailedScheduling') && c.includes('Unschedulable')
+      )
   )
-  return [...containerErrors, ...terminatedErrors, ...eventErrors, ...conditionErrors]
+  return [
+    ...containerErrors,
+    ...terminatedErrors,
+    ...eventErrors,
+    ...conditionErrors
+  ]
 }
 
 export async function waitForPodPhases(
@@ -1375,6 +1537,10 @@ export async function waitForPodPhases(
   maxTimeSeconds = DEFAULT_WAIT_FOR_POD_TIME_SECONDS
 ): Promise<void> {
   const backOffManager = new BackOffManager(maxTimeSeconds)
+  // Per-container first-observation timestamps for the image-pull grace window
+  // (see evaluateImagePullFailures). Mutated in place across poll iterations.
+  const imagePullFirstSeen = new Map<string, number>()
+  const imagePullGraceMs = getImagePullGraceMs()
   let phase: PodPhase = PodPhase.UNKNOWN
   while (true) {
     let pod: k8s.V1Pod
@@ -1423,14 +1589,22 @@ export async function waitForPodPhases(
       )
     }
 
-    // Still in a back-off phase, but a deterministic unrecoverable error
-    // was detected (container / event / condition). Fail fast with
-    // diagnostics instead of waiting out the full timeout.
+    // Still in a back-off phase, but a deterministic unrecoverable error was
+    // detected (container / event / condition) OR an image-pull failure has
+    // persisted past its grace period / matched a permanent pattern. Fail fast
+    // with diagnostics instead of waiting out the full timeout.
+    const imagePullErrors = evaluateImagePullFailures(
+      pod,
+      imagePullFirstSeen,
+      imagePullGraceMs,
+      Date.now()
+    )
     const errors = await checkUnrecoverableErrors(pod, podName)
-    if (errors.length > 0) {
+    const allErrors = [...imagePullErrors, ...errors]
+    if (allErrors.length > 0) {
       const details = await describePodFailure(podName)
       throw new Error(
-        `Pod ${podName} has unrecoverable errors:\n${errors.join('\n')}\n${'-'.repeat(60)}\n${details}`
+        `Pod ${podName} has unrecoverable errors:\n${allErrors.join('\n')}\n${'-'.repeat(60)}\n${details}`
       )
     }
 

--- a/packages/k8s/tests/wait-for-pod-phases-test.ts
+++ b/packages/k8s/tests/wait-for-pod-phases-test.ts
@@ -1,8 +1,10 @@
 import * as k8s from '@kubernetes/client-node'
 import {
   describePodFailure,
+  evaluateImagePullFailures,
   getContainerErrors,
   getContainerTerminatedErrors,
+  getImagePullGraceMs,
   getPodEventErrors,
   getUnrecoverableEventReasons,
   getUnrecoverableTerminatedReasons,
@@ -125,7 +127,10 @@ describe('getContainerErrors', () => {
     }
   })
 
-  it('includes retry-history and network hint for ImagePullBackOff', () => {
+  it('does not fast-fail on ImagePullBackOff (handled by the grace period)', () => {
+    // ImagePullBackOff is NOT an immediate unrecoverable reason: a transient
+    // network outage can self-heal. waitForPodPhases gives it a bounded grace
+    // period (see evaluateImagePullFailures) before failing.
     const pod = buildPod(PodPhase.PENDING, {
       containerStatuses: [
         waitingContainer(
@@ -135,19 +140,16 @@ describe('getContainerErrors', () => {
         )
       ]
     })
-    const errors = getContainerErrors(pod)
-    expect(errors).toHaveLength(1)
-    expect(errors[0]).toContain('  ✗ container "job": ImagePullBackOff')
-    expect(errors[0]).toContain('Back-off pulling image "does-not-exist:latest"')
-    expect(errors[0]).toContain('registry')
-    expect(errors[0]).toContain('TLS')
+    expect(getContainerErrors(pod)).toEqual([])
   })
 
-  it('does not fast-fail on ErrImagePull (treated as transient first-attempt)', () => {
+  it('does not fast-fail on ErrImagePull (treated as transient, grace period applies)', () => {
     // ErrImagePull fires on the first pull failure (could be a TLS timeout).
     // k8s will retry and promote to ImagePullBackOff if it keeps failing.
     const pod = buildPod(PodPhase.PENDING, {
-      containerStatuses: [waitingContainer('job', 'ErrImagePull', 'TLS handshake timeout')]
+      containerStatuses: [
+        waitingContainer('job', 'ErrImagePull', 'TLS handshake timeout')
+      ]
     })
     expect(getContainerErrors(pod)).toEqual([])
   })
@@ -161,12 +163,16 @@ describe('getContainerErrors', () => {
 
   it('inspects init containers as well as regular containers', () => {
     const pod = buildPod(PodPhase.PENDING, {
-      initContainerStatuses: [waitingContainer('init', 'ImagePullBackOff')],
+      initContainerStatuses: [
+        waitingContainer('init', 'CreateContainerConfigError')
+      ],
       containerStatuses: [waitingContainer('job', 'InvalidImageName')]
     })
     const errors = getContainerErrors(pod)
     expect(errors).toHaveLength(2)
-    expect(errors[0]).toContain('  ✗ container "init": ImagePullBackOff')
+    expect(errors[0]).toContain(
+      '  ✗ container "init": CreateContainerConfigError'
+    )
     expect(errors[1]).toContain('  ✗ container "job": InvalidImageName')
   })
 
@@ -180,6 +186,155 @@ describe('getContainerErrors', () => {
     const errors = getContainerErrors(pod)
     expect(errors).toHaveLength(1)
     expect(errors[0]).toContain('  ✗ container "bad": InvalidImageName')
+  })
+})
+
+describe('getImagePullGraceMs', () => {
+  afterEach(() => {
+    delete process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS']
+  })
+
+  it('returns the default 5 minutes when the env var is unset', () => {
+    expect(getImagePullGraceMs()).toBe(5 * 60 * 1000)
+  })
+
+  it('reads ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS in seconds', () => {
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS'] = '120'
+    expect(getImagePullGraceMs()).toBe(120 * 1000)
+  })
+
+  it('returns 0 when grace is set to 0 (immediate fail, old behavior)', () => {
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS'] = '0'
+    expect(getImagePullGraceMs()).toBe(0)
+  })
+
+  it('falls back to the default for invalid or negative values', () => {
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS'] = 'abc'
+    expect(getImagePullGraceMs()).toBe(5 * 60 * 1000)
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS'] = '-5'
+    expect(getImagePullGraceMs()).toBe(5 * 60 * 1000)
+  })
+})
+
+describe('evaluateImagePullFailures', () => {
+  it('returns no errors when there are no image-pull failures', () => {
+    const firstSeen = new Map<string, number>()
+    const pod = buildPod(PodPhase.PENDING, {
+      containerStatuses: [waitingContainer('job', 'ContainerCreating')]
+    })
+    expect(evaluateImagePullFailures(pod, firstSeen, 300000, 1000)).toEqual([])
+    expect(firstSeen.size).toBe(0)
+  })
+
+  it('records first observation and stays silent within the grace period', () => {
+    const firstSeen = new Map<string, number>()
+    const pod = buildPod(PodPhase.PENDING, {
+      containerStatuses: [
+        waitingContainer(
+          'job',
+          'ImagePullBackOff',
+          'Back-off pulling image "nope:latest"'
+        )
+      ]
+    })
+    expect(evaluateImagePullFailures(pod, firstSeen, 300000, 1000)).toEqual([])
+    expect(firstSeen.get('job')).toBe(1000)
+    // Still within grace on a later poll.
+    expect(
+      evaluateImagePullFailures(pod, firstSeen, 300000, 1000 + 299999)
+    ).toEqual([])
+  })
+
+  it('errors for ImagePullBackOff and ErrImagePull once the grace period expires', () => {
+    const firstSeen = new Map<string, number>()
+    const pod = buildPod(PodPhase.PENDING, {
+      containerStatuses: [
+        waitingContainer('job', 'ImagePullBackOff'),
+        waitingContainer('svc', 'ErrImagePull', 'TLS handshake timeout')
+      ]
+    })
+    const now = 1000
+    evaluateImagePullFailures(pod, firstSeen, 300000, now)
+    const errors = evaluateImagePullFailures(
+      pod,
+      firstSeen,
+      300000,
+      now + 300000
+    )
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toContain('  ✗ container "job": ImagePullBackOff')
+    expect(errors[0]).toContain('exceeding the 300s grace period')
+    expect(errors[0]).toContain('→')
+    expect(errors[1]).toContain('  ✗ container "svc": ErrImagePull')
+  })
+
+  it('fails immediately on a permanent image-pull error message', () => {
+    const firstSeen = new Map<string, number>()
+    const pod = buildPod(PodPhase.PENDING, {
+      containerStatuses: [
+        waitingContainer(
+          'job',
+          'ImagePullBackOff',
+          'pull access denied for nope/nonexistent, repository does not exist or may require docker login'
+        )
+      ]
+    })
+    const errors = evaluateImagePullFailures(pod, firstSeen, 300000, 1000)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('  ✗ container "job": ImagePullBackOff')
+    expect(errors[0]).toContain('(permanent image error)')
+  })
+
+  it('does not reset the grace window while the failure persists', () => {
+    const firstSeen = new Map<string, number>()
+    const pod = buildPod(PodPhase.PENDING, {
+      containerStatuses: [waitingContainer('job', 'ImagePullBackOff')]
+    })
+    evaluateImagePullFailures(pod, firstSeen, 300000, 1000)
+    evaluateImagePullFailures(pod, firstSeen, 300000, 50000)
+    expect(firstSeen.get('job')).toBe(1000)
+  })
+
+  it('clears tracking on recovery so a later failure gets a fresh grace window', () => {
+    const firstSeen = new Map<string, number>()
+    const failing = buildPod(PodPhase.PENDING, {
+      containerStatuses: [waitingContainer('job', 'ImagePullBackOff')]
+    })
+    const recovered = buildPod(PodPhase.PENDING, {
+      containerStatuses: [
+        { name: 'job', state: { running: {} } } as k8s.V1ContainerStatus
+      ]
+    })
+    evaluateImagePullFailures(failing, firstSeen, 300000, 1000)
+    expect(firstSeen.size).toBe(1)
+    evaluateImagePullFailures(recovered, firstSeen, 300000, 2000)
+    expect(firstSeen.size).toBe(0)
+    // A fresh failure starts a new grace window.
+    expect(evaluateImagePullFailures(failing, firstSeen, 300000, 3000)).toEqual(
+      []
+    )
+  })
+
+  it('tracks containers independently', () => {
+    const firstSeen = new Map<string, number>()
+    const now = 1000
+    firstSeen.set('old', now) // 'old' has been failing since `now`
+    const pod = buildPod(PodPhase.PENDING, {
+      containerStatuses: [
+        waitingContainer('old', 'ImagePullBackOff'),
+        waitingContainer('fresh', 'ImagePullBackOff')
+      ]
+    })
+    const errors = evaluateImagePullFailures(
+      pod,
+      firstSeen,
+      300000,
+      now + 300000
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('container "old"')
+    expect(errors[0]).not.toContain('"fresh"')
+    expect(firstSeen.get('fresh')).toBe(now + 300000)
   })
 })
 
@@ -258,7 +413,9 @@ describe('getPodEventErrors', () => {
     }
     // No message at all — unknown cause, treat as transient
     eventSpy.mockResolvedValue(
-      eventResult([{ type: 'Warning', reason: 'FailedScheduling' } as k8s.CoreV1Event])
+      eventResult([
+        { type: 'Warning', reason: 'FailedScheduling' } as k8s.CoreV1Event
+      ])
     )
     expect(await getPodEventErrors('my-pod')).toEqual([])
   })
@@ -280,7 +437,9 @@ describe('getPodEventErrors', () => {
 
   it('ignores Normal-type events even if the reason matches', async () => {
     eventSpy.mockResolvedValue(
-      eventResult([buildEvent('FailedMount', 'volume not found', { type: 'Normal' })])
+      eventResult([
+        buildEvent('FailedMount', 'volume not found', { type: 'Normal' })
+      ])
     )
     expect(await getPodEventErrors('my-pod')).toEqual([])
   })
@@ -349,14 +508,28 @@ describe('isPermanentSchedulingFailure', () => {
   })
 
   it('returns false for resource shortages (transient — keep queuing)', () => {
-    expect(isPermanentSchedulingFailure('0/3 nodes are available: 3 Insufficient nvidia.com/gpu.')).toBe(false)
-    expect(isPermanentSchedulingFailure('0/5 nodes are available: 5 Insufficient memory.')).toBe(false)
-    expect(isPermanentSchedulingFailure('0/2 nodes are available: 2 Insufficient cpu.')).toBe(false)
+    expect(
+      isPermanentSchedulingFailure(
+        '0/3 nodes are available: 3 Insufficient nvidia.com/gpu.'
+      )
+    ).toBe(false)
+    expect(
+      isPermanentSchedulingFailure(
+        '0/5 nodes are available: 5 Insufficient memory.'
+      )
+    ).toBe(false)
+    expect(
+      isPermanentSchedulingFailure(
+        '0/2 nodes are available: 2 Insufficient cpu.'
+      )
+    ).toBe(false)
   })
 
   it('returns false for ambiguous / unknown messages (safe default: keep queuing)', () => {
     expect(isPermanentSchedulingFailure('0/1 nodes are available')).toBe(false)
-    expect(isPermanentSchedulingFailure('preemption: 0/3 nodes are available')).toBe(false)
+    expect(
+      isPermanentSchedulingFailure('preemption: 0/3 nodes are available')
+    ).toBe(false)
     expect(isPermanentSchedulingFailure(undefined)).toBe(false)
   })
 
@@ -438,9 +611,7 @@ describe('getContainerTerminatedErrors', () => {
 
   it('returns no errors for terminated containers with recoverable reasons', () => {
     const pod = buildPod(PodPhase.SUCCEEDED, {
-      containerStatuses: [
-        terminatedContainer('fs-init', 'Completed', 0)
-      ]
+      containerStatuses: [terminatedContainer('fs-init', 'Completed', 0)]
     })
     expect(getContainerTerminatedErrors(pod)).toEqual([])
   })
@@ -448,12 +619,19 @@ describe('getContainerTerminatedErrors', () => {
   it('detects OOMKilled and includes hint', () => {
     const pod = buildPod(PodPhase.FAILED, {
       containerStatuses: [
-        terminatedContainer('job', 'OOMKilled', 137, 'The node was low on resource: memory')
+        terminatedContainer(
+          'job',
+          'OOMKilled',
+          137,
+          'The node was low on resource: memory'
+        )
       ]
     })
     const errors = getContainerTerminatedErrors(pod)
     expect(errors).toHaveLength(1)
-    expect(errors[0]).toContain('  ✗ container "job": OOMKilled (exit code 137)')
+    expect(errors[0]).toContain(
+      '  ✗ container "job": OOMKilled (exit code 137)'
+    )
     expect(errors[0]).toContain('The node was low on resource: memory')
     expect(errors[0]).toContain('memory limit')
   })
@@ -488,12 +666,19 @@ describe('getContainerTerminatedErrors', () => {
   it('detects FailedPostStartHookError and includes hint', () => {
     const pod = buildPod(PodPhase.FAILED, {
       containerStatuses: [
-        terminatedContainer('job', 'FailedPostStartHookError', 137, 'postStart hook failed')
+        terminatedContainer(
+          'job',
+          'FailedPostStartHookError',
+          137,
+          'postStart hook failed'
+        )
       ]
     })
     const errors = getContainerTerminatedErrors(pod)
     expect(errors).toHaveLength(1)
-    expect(errors[0]).toContain('  ✗ container "job": FailedPostStartHookError (exit code 137)')
+    expect(errors[0]).toContain(
+      '  ✗ container "job": FailedPostStartHookError (exit code 137)'
+    )
     expect(errors[0]).toContain('postStart hook failed')
     expect(errors[0]).toContain('postStart lifecycle hook')
   })
@@ -505,7 +690,9 @@ describe('getContainerTerminatedErrors', () => {
       })
       const errors = getContainerTerminatedErrors(pod)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toContain(`  ✗ container "job": ${reason} (exit code 1)`)
+      expect(errors[0]).toContain(
+        `  ✗ container "job": ${reason} (exit code 1)`
+      )
     }
   })
 
@@ -517,14 +704,14 @@ describe('getContainerTerminatedErrors', () => {
     const errors = getContainerTerminatedErrors(pod)
     expect(errors).toHaveLength(2)
     expect(errors[0]).toContain('  ✗ container "init": Error (exit code 2)')
-    expect(errors[1]).toContain('  ✗ container "job": OOMKilled (exit code 137)')
+    expect(errors[1]).toContain(
+      '  ✗ container "job": OOMKilled (exit code 137)'
+    )
   })
 
   it('ignores terminated with reason not in the whitelist', () => {
     const pod = buildPod(PodPhase.SUCCEEDED, {
-      containerStatuses: [
-        terminatedContainer('job', 'Completed', 0)
-      ]
+      containerStatuses: [terminatedContainer('job', 'Completed', 0)]
     })
     expect(getContainerTerminatedErrors(pod)).toEqual([])
   })
@@ -536,7 +723,9 @@ describe('getUnrecoverableTerminatedReasons', () => {
   })
 
   it('returns the built-in defaults when the env var is unset', () => {
-    expect(getUnrecoverableTerminatedReasons()).toEqual(UNRECOVERABLE_TERMINATED_REASONS)
+    expect(getUnrecoverableTerminatedReasons()).toEqual(
+      UNRECOVERABLE_TERMINATED_REASONS
+    )
   })
 
   it('adds extra reasons from the env var without dropping the defaults', () => {
@@ -558,7 +747,9 @@ describe('getUnrecoverableTerminatedReasons', () => {
     })
     const errors = getContainerTerminatedErrors(pod)
     expect(errors).toHaveLength(1)
-    expect(errors[0]).toContain('  ✗ container "job": DeadlineExceeded (exit code 1)')
+    expect(errors[0]).toContain(
+      '  ✗ container "job": DeadlineExceeded (exit code 1)'
+    )
   })
 
   it('filters empty strings from the env var', () => {
@@ -590,6 +781,7 @@ describe('waitForPodPhases', () => {
   afterEach(() => {
     jest.restoreAllMocks()
     delete process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE']
+    delete process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS']
   })
 
   it('returns once the pod reaches an awaited phase', async () => {
@@ -605,6 +797,27 @@ describe('waitForPodPhases', () => {
   })
 
   it('surfaces unrecoverable container errors in the thrown message', async () => {
+    readSpy.mockResolvedValue(
+      podResult(
+        buildPod(PodPhase.PENDING, {
+          containerStatuses: [
+            waitingContainer('job', 'InvalidImageName', 'nope')
+          ]
+        })
+      )
+    )
+
+    await expect(
+      waitForPodPhases(
+        'my-pod',
+        new Set([PodPhase.RUNNING]),
+        new Set([PodPhase.PENDING])
+      )
+    ).rejects.toThrow('Pod my-pod has unrecoverable errors')
+  })
+
+  it('fails immediately on ImagePullBackOff when grace is set to 0 (old behavior)', async () => {
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS'] = '0'
     readSpy.mockResolvedValue(
       podResult(
         buildPod(PodPhase.PENDING, {
@@ -625,7 +838,55 @@ describe('waitForPodPhases', () => {
         new Set([PodPhase.RUNNING]),
         new Set([PodPhase.PENDING])
       )
-    ).rejects.toThrow('Pod my-pod has unrecoverable errors')
+    ).rejects.toThrow(/has unrecoverable errors:[\s\S]*ImagePullBackOff/)
+  })
+
+  it('keeps polling an image-pull failure within the grace period and succeeds once the pod becomes ready', async () => {
+    // Default grace (300s): a fresh ImagePullBackOff must NOT fail the job.
+    readSpy
+      .mockResolvedValueOnce(
+        podResult(
+          buildPod(PodPhase.PENDING, {
+            containerStatuses: [waitingContainer('job', 'ImagePullBackOff')]
+          })
+        )
+      )
+      .mockResolvedValueOnce(podResult(buildPod(PodPhase.RUNNING)))
+
+    await expect(
+      waitForPodPhases(
+        'my-pod',
+        new Set([PodPhase.RUNNING]),
+        new Set([PodPhase.PENDING])
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('fails immediately on a permanent image error even with a large grace period', async () => {
+    process.env['ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS'] = '600'
+    readSpy.mockResolvedValue(
+      podResult(
+        buildPod(PodPhase.PENDING, {
+          containerStatuses: [
+            waitingContainer(
+              'job',
+              'ImagePullBackOff',
+              'pull access denied for nope/nonexistent, repository does not exist or may require docker login'
+            )
+          ]
+        })
+      )
+    )
+
+    await expect(
+      waitForPodPhases(
+        'my-pod',
+        new Set([PodPhase.RUNNING]),
+        new Set([PodPhase.PENDING])
+      )
+    ).rejects.toThrow(
+      /has unrecoverable errors:[\s\S]*\(permanent image error\)/
+    )
   })
 
   it('fast-fails on FailedMount events instead of polling to timeout', async () => {
@@ -670,7 +931,11 @@ describe('waitForPodPhases', () => {
       ])
     )
     await expect(
-      waitForPodPhases('my-pod', new Set([PodPhase.RUNNING]), new Set([PodPhase.PENDING]))
+      waitForPodPhases(
+        'my-pod',
+        new Set([PodPhase.RUNNING]),
+        new Set([PodPhase.PENDING])
+      )
     ).rejects.toThrow(/has unrecoverable errors:[\s\S]*event: FailedScheduling/)
   })
 
@@ -679,10 +944,19 @@ describe('waitForPodPhases', () => {
       .mockResolvedValueOnce(podResult(buildPod(PodPhase.PENDING)))
       .mockResolvedValueOnce(podResult(buildPod(PodPhase.RUNNING)))
     eventSpy.mockResolvedValue(
-      eventResult([buildEvent('FailedScheduling', '0/3 nodes are available: 3 Insufficient nvidia.com/gpu.')])
+      eventResult([
+        buildEvent(
+          'FailedScheduling',
+          '0/3 nodes are available: 3 Insufficient nvidia.com/gpu.'
+        )
+      ])
     )
     await expect(
-      waitForPodPhases('my-pod', new Set([PodPhase.RUNNING]), new Set([PodPhase.PENDING]))
+      waitForPodPhases(
+        'my-pod',
+        new Set([PodPhase.RUNNING]),
+        new Set([PodPhase.PENDING])
+      )
     ).resolves.toBeUndefined()
   })
 


### PR DESCRIPTION
## 描述
<!-- 请简要描述这个 PR 的目的和变更内容 -->
根因: 
原以为 ImagePullBackOff 是 k8s 退避多次后才出现。实际 k8s 第 2 次拉取失败就切到 ImagePullBackOff，所以旧代码（它已在 UNRECOVERABLE_WAITING_REASONS）几乎立即 fail，瞬时网络差就杀 job。

改动:
- ImagePullBackOff 移出立即 fail 集合
- 新增 evaluateImagePullFailures()：每容器独立记录首次失败时间，宽限期内自愈则清除计时，持续超宽限才报错
- 宽限期 ACTIONS_RUNNER_K8S_IMAGE_PULL_GRACE_SECONDS（默认 300s，你的部署已配 PREPARE_JOB_TIMEOUT_SECONDS=3600，宽限远小于 1h）
- PERMANENT_IMAGE_PULL_PATTERNS：镜像不存在/凭据错/unauthorized 等永久性消息 → 立即 fail，不空等宽限
- grace=0 → 恢复旧行为（立即 fail）

## 相关 Issue
<!-- 链接到相关的 issue，使用关键字，如：resolve https://github.com/opensourceways/{repo}/issues/2 -->
resolve https://github.com/opensourceways/backlog/issues/1586

## 变更类型
<!-- 请勾选适用的变更类型 -->
- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
